### PR TITLE
Layout options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 ConfigArgParse==1.2.3
 graphviz==0.14.1
+regex                  # for awesome-slugify
+unicode                # for awesome-slugify
 awesome-slugify==1.6.5
 requests
 certifi                # for requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ConfigArgParse==1.2.3
 graphviz==0.14.1
+awesome-slugify==1.6.5
 requests
 certifi                # for requests
 chardet                # for requests

--- a/src/katsdpnetboxutilities/connect.py
+++ b/src/katsdpnetboxutilities/connect.py
@@ -1,12 +1,13 @@
-import re
-import os
 import json
 import logging
+import time
 
 from urllib.parse import urljoin
+from pathlib import Path
 
 import requests
 
+from slugify import slugify
 
 def _query_netbox(url, token, path, query=None):
     headers = {
@@ -14,31 +15,46 @@ def _query_netbox(url, token, path, query=None):
         "Content-Type": "application/json",
         "Accept": "application/json; indent=4",
     }
-    r = requests.get(urljoin(url, path), headers=headers, params=query)
-    return r.json()
+    if query:
+        query.setdefault('limit', 10000)
+    req = requests.get(urljoin(url, path), headers=headers, params=query)
+    return req.json()
 
+def _query_netbox_url(url, path, query=None):
+    if query:
+        query.setdefault('limit', 1000)
+    prepped = requests.Request('GET', urljoin(url, path), params=query).prepare()
+    return prepped.url
+
+def _load_cache(filename):
+    if filename.is_file():
+        age = time.time() - filename.stat().st_mtime
+        if age < 36000:  # 10h # TODO: Make this a configuration value.
+            with open(filename) as fh:
+                logging.info("Reading results from %s", filename)
+                return json.load(fh)
+
+def _save_cache(data, filename):
+    if data:
+        with open(filename, "w+") as fh:
+            logging.info("Saving results to %s", filename)
+            json.dump(data, fh)
+    else:
+        logging.debug("SaveCache: Missing data, nothing cached.")
 
 def query_netbox(config, path, query=None):
-    # TODO: add cache expire after 1Day.
-    if config["cache_path"]:
-        filename = path + "_"
-        if query:
-            filename += "_".join(["{}={}".format(k, v) for k, v in query.items()])
-        filename = re.sub(r"[\W_]+", "_", filename)
-        cache_filename = os.path.join(
-            config["cache_path"], filename.strip("_") + ".json"
-        )
-        if os.path.isfile(cache_filename):
-            with open(cache_filename) as fh:
-                logging.info("Reading results from %s", cache_filename)
-                return json.load(fh)
-        else:
-            data = _query_netbox(config["url"], config["token"], path, query)
-            with open(cache_filename, "w+") as fh:
-                logging.info("Saving results to %s", cache_filename)
-                json.dump(data, fh)
-            return data
+    data = None
+    url = config["url"]
 
-    else:
-        data = _query_netbox(config["url"], config["token"], path, query)
+    if config["cache_path"]:
+        filename = slugify(_query_netbox_url(url, path, query)) + ".json"
+        cache_filename = Path(config["cache_path"]) / filename
+        data = _load_cache(cache_filename)
+
+    if not data:
+        data = _query_netbox(url, config["token"], path, query)
+
+    if config["cache_path"]:
+        _save_cache(data, cache_filename)
+
     return data

--- a/src/katsdpnetboxutilities/network/diagram.py
+++ b/src/katsdpnetboxutilities/network/diagram.py
@@ -18,6 +18,7 @@ def parse_args():
     p.add("--token", help="Netbox connection token")
     p.add("--url", help="Netbox server URL")
     p.add("--cache-path", help="Directory to store temporary results")
+    p.add("--cache-age", help="How old cache objects can get (minutes)", default=600)
     p.add(
         "-o",
         "--output-path",

--- a/src/katsdpnetboxutilities/network/diagram.py
+++ b/src/katsdpnetboxutilities/network/diagram.py
@@ -29,6 +29,24 @@ def parse_args():
     p.add("-v", "--verbose", help="Verbose", action="store_true")
     p.add("-d", "--debug", help="Debug", action="store_true")
     p.add("-l", "--live", help="Live view, display the graph", action="store_true")
+    p.add(
+        "--subgraph",
+        help="Make nodes subgraphs, do not work with all engines",
+        action="store_true",
+    )
+    p.add(
+        "--horizontal",
+        help="Attempt to produce a horizontal layout if possible",
+        action="store_true",
+    )
+    p.add(
+        "-e",
+        "--engine",
+        help="Graph layout engine to use",
+        default="dot",
+        choices=["dot", "neato", "sfdp", "circo"],
+    )
+    p.add("-f", "--format", help="Output format", default="pdf", choices=["pdf", "png"])
     p.add("search", nargs="+", help="Netbox search filter")
     config = vars(p.parse_args())
 

--- a/src/katsdpnetboxutilities/network/utils.py
+++ b/src/katsdpnetboxutilities/network/utils.py
@@ -45,12 +45,11 @@ def create_graphviz(edges, subgraphs):
 def make_dot_file(config, dataset):
     edges, subgraphs = extract_edges_subgraphs_from_netbox_result(dataset)
     graph = create_graphviz(edges, subgraphs)
-    filename = os.path.join(config["output_path"], config["name"] + ".gv")
-    # graph.save(filename)
-    graph.save(directory=config["output_path"], filename=config["name"])
+    filename = config["name"] + ".gv"
+    graph.save(directory=config["output_path"], filename=filename)
     graph.render(
         directory=config["output_path"],
-        filename=config["name"],
+        filename=filename,
         view=config["live"],
         format="pdf",
     )

--- a/src/katsdpnetboxutilities/network/utils.py
+++ b/src/katsdpnetboxutilities/network/utils.py
@@ -6,8 +6,10 @@ from collections import defaultdict
 from graphviz import Graph
 
 
-def extract_edges_subgraphs_from_netbox_result(dataset):
+def extract_components_from_netbox_result(dataset, config):
     edges = []
+    nodes = []
+    records = defaultdict(dict)
     subgraphs = defaultdict(dict)
     for link in dataset:
         logging.debug("link: %s", link)
@@ -16,17 +18,41 @@ def extract_edges_subgraphs_from_netbox_result(dataset):
         intf_a = "i{}".format(link["interface_a"]["id"])
         device_b = "d{}".format(link["interface_b"]["device"]["id"])
         intf_b = "i{}".format(link["interface_b"]["id"])
-        subgraphs[device_a]["_info"] = link["interface_a"]["device"]
-        subgraphs[device_b]["_info"] = link["interface_b"]["device"]
-        subgraphs[device_a][intf_a] = link["interface_a"]
-        subgraphs[device_b][intf_b] = link["interface_b"]
+        if config['subgraph']:
+            subgraphs[device_a]["_info"] = link["interface_a"]["device"]
+            subgraphs[device_b]["_info"] = link["interface_b"]["device"]
+            subgraphs[device_a][intf_a] = link["interface_a"]
+            subgraphs[device_b][intf_b] = link["interface_b"]
+        else:
+            records[device_a]["_info"] = link["interface_a"]["device"]
+            records[device_b]["_info"] = link["interface_b"]["device"]
+            records[device_a][intf_a] = link["interface_a"]
+            records[device_b][intf_b] = link["interface_b"]
+            intf_a = "{}:{}".format(device_a, intf_a)
+            intf_b = "{}:{}".format(device_b, intf_b)
         edges.append({"a": intf_a, "b": intf_b})
-    return edges, subgraphs
+    return {"edges": edges, "nodes": nodes, "subgraphs": subgraphs, "records": records}
 
 
-def create_graphviz(edges, subgraphs):
-    graph = Graph(name="sarao")
-    graph.attr(rankdir='LR', overlap='false')
+def add_edges(graph, edges):
+    for edge in edges:
+        graph.edge(edge["a"], edge["b"])
+
+
+def add_nodes(graph, nodes):
+    pass
+
+
+def add_records(graph, records):
+    for record_name, record in records.items():
+        label = "{}".format(record["_info"]["name"])
+        for intf_name, intf in record.items():
+            if not intf_name.startswith("_"):
+                label += "|<{}> {}".format(intf_name, intf["name"])
+        graph.node(name=record_name, shape="record", label=label, url=intf["url"])
+
+
+def add_subgraphs(graph, subgraphs):
     for subgraph_name, subgraph in subgraphs.items():
         with graph.subgraph(name="cluster_" + subgraph_name) as subg:
             subg.attr(label=subgraph["_info"]["name"])
@@ -37,20 +63,33 @@ def create_graphviz(edges, subgraphs):
                         name=intf_name, shape="box", label=intf["name"], url=intf["url"]
                     )
 
-    for edge in edges:
-        graph.edge(edge["a"], edge["b"])
+
+def create_graphviz(components, config):
+    graph = Graph(
+        name=config["name"], engine=config["engine"], directory=config["output_path"]
+    )
+    if config.get("horizontal"):
+        rankdir = "TB"
+    else:
+        rankdir = "LR"
+    graph.attr(rankdir="LR", overlap="false")
+
+    add_subgraphs(graph, components["subgraphs"])
+    add_records(graph, components["records"])
+    add_nodes(graph, components["nodes"])
+    add_edges(graph, components["edges"])
 
     return graph
 
 
 def make_dot_file(config, dataset):
-    edges, subgraphs = extract_edges_subgraphs_from_netbox_result(dataset)
-    graph = create_graphviz(edges, subgraphs)
+    components = extract_components_from_netbox_result(dataset, config)
+    graph = create_graphviz(components, config)
     filename = config["name"] + ".gv"
     graph.save(directory=config["output_path"], filename=filename)
     graph.render(
         directory=config["output_path"],
         filename=filename,
         view=config["live"],
-        format="pdf",
+        format=config["format"],
     )

--- a/src/katsdpnetboxutilities/network/utils.py
+++ b/src/katsdpnetboxutilities/network/utils.py
@@ -26,6 +26,7 @@ def extract_edges_subgraphs_from_netbox_result(dataset):
 
 def create_graphviz(edges, subgraphs):
     graph = Graph(name="sarao")
+    graph.attr(rankdir='LR', overlap='false')
     for subgraph_name, subgraph in subgraphs.items():
         with graph.subgraph(name="cluster_" + subgraph_name) as subg:
             subg.attr(label=subgraph["_info"]["name"])


### PR DESCRIPTION
Review after #5 has been merged.

This PR adds a few options to change the look of the output.
--subgraph
The default node type is now a record. When you want to render it as a subgraph add the argument --subgraph

--format
The output can be saved as pdf or png

--horizontal
The default now is to create vertical graphs. But if you need a horizontal layout add the argument --horizontal

--engine
The default layout engine is still dot. But this option allows you to select the other layout engines.

```
usage: netboxutilities-network-diagram [-h] [-c CONFIG] [--token TOKEN] [--url URL] [--cache-path CACHE_PATH] [--cache-age CACHE_AGE] -o OUTPUT_PATH -n
                                       NAME [-v] [-d] [-l] [--subgraph] [--horizontal] [-e {dot,neato,sfdp,circo}] [-f {pdf,png}]
                                       search [search ...]

Args that start with '--' (eg. --token) can also be set in a config file (~/.config/sarao/netbox or specified via -c). Config file syntax allows:
key=value, flag=true, stuff=[a,b,c] (for details, see syntax at https://goo.gl/R74nmi). If an arg is specified in more than one place, then commandline
values override config file values which override defaults.

positional arguments:
  search                Netbox search filter

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        config file
  --token TOKEN         Netbox connection token
  --url URL             Netbox server URL
  --cache-path CACHE_PATH
                        Directory to store temporary results
  --cache-age CACHE_AGE
                        How old cache objects can get (minutes)
  -o OUTPUT_PATH, --output-path OUTPUT_PATH
                        Path where the output files will be stored
  -n NAME, --name NAME  Graph name
  -v, --verbose         Verbose
  -d, --debug           Debug
  -l, --live            Live view, display the graph
  --subgraph            Make nodes subgraphs, do not work with all engines
  --horizontal          Attempt to produce a horizontal layout if possible
  -e {dot,neato,sfdp,circo}, --engine {dot,neato,sfdp,circo}
                        Graph layout engine to use
  -f {pdf,png}, --format {pdf,png}
                        Output format

```